### PR TITLE
Feature/catch up with 2.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 .DS_Store
 lib/.DS_Store
 coverage.html
+.vimrc

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-Heapsource <npm@heapsource.com> (http://www.heapsource.com)
+Bithavoc <im@bithavoc.io> (https://bithavoc.io)
 Lars Jacob (http://jaclar.net)
 Jonathan Lomas (http://floatinglomas.ca)
 Xavier Damman (http://xdamman.com)
@@ -6,3 +6,4 @@ Quentin Rossetti <quentin.rossetti@gmail.com>
 Damian Kaczmarek <rush@rushbase.net>
 Robbie Trencheny <me@robbiet.us> (http://robbie.io)
 Ross Brandes <ross.brandes@gmail.com>
+Kévin Maschtaler (https://www.kmaschta.me)

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)
       msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
       expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
-      colorize: true, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
+      colorize: false, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
       ignoreRoute: function (req, res) { return false; } // optional: allows to skip some log messages based on request and/or response
     }));
 

--- a/Readme.md
+++ b/Readme.md
@@ -383,7 +383,7 @@ If you set statusLevels to true express-winston will log sub 400 responses at in
   }
 ```
 
-## Dynamica Status Levels
+## Dynamic Status Levels
 
 If you set statusLevels to false and assign a function to level, you can customize the log level for any scenario.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "middleware",
     "colors"
   ],
-  "version": "2.4.0",
+  "version": "2.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bithavoc/express-winston.git"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "lodash": "~4.11.1"
+    "lodash": "~4.17.5"
   },
   "devDependencies": {
     "blanket": "^1.2.2",


### PR DESCRIPTION
Fixes security vulnerability and memory usage
https://github.com/bithavoc/express-winston/releases/tag/v2.5.0

Lodash must be updated in Skyhawk-util but this project is using an exact version of Lodash.